### PR TITLE
Refactor: Separate repository and service layers for Mongo and Qdrant

### DIFF
--- a/app/container/core_container.py
+++ b/app/container/core_container.py
@@ -2,6 +2,9 @@ from app.clients.mongo_client import MongoDBClient
 from app.clients.qdrant_client import QdrantDBClient
 from app.clients.cohere_client import CohereEmbeddingClient
 
+from app.repositories.mongo_repository import MongoRepository
+from app.repositories.qdrant_repository import QdrantRepository
+
 from app.services.mongo_service import MongoService
 from app.services.qdrant_service import QdrantService
 from app.services.processing import ProcessingService
@@ -25,11 +28,15 @@ cohere_client = CohereEmbeddingClient(
     api_key=settings.COHERE_API_KEY
 )
 
-# Initialize services
-mongo_service = MongoService(mongo_client)
-qdrant_service = QdrantService(qdrant_client)
+# Initialize repositories
+mongo_repository = MongoRepository(mongo_client)
+qdrant_repository = QdrantRepository(qdrant_client)
 
-# Pass all needed services to ProcessingService
+# Initialize services
+mongo_service = MongoService(mongo_repository)
+qdrant_service = QdrantService(qdrant_repository)
+
+# Processing service uses both mongo and qdrant services + cohere client
 processing_service = ProcessingService(
     cohere_client=cohere_client,
     mongo_service=mongo_service,
@@ -39,10 +46,16 @@ processing_service = ProcessingService(
 # Dependency container
 class Container:
     def __init__(self):
+        self.mongo_client = mongo_client
+        self.qdrant_client = qdrant_client
+        self.cohere_client = cohere_client
+
+        self.mongo_repository = mongo_repository
+        self.qdrant_repository = qdrant_repository
+
         self.mongo_service = mongo_service
         self.qdrant_service = qdrant_service
         self.processing_service = processing_service
-        self.cohere_client = cohere_client  # Optional: exposed in case needed directly
 
 # Exported container instance
 container = Container()

--- a/app/repositories/mongo_repository.py
+++ b/app/repositories/mongo_repository.py
@@ -1,0 +1,25 @@
+from app.clients.mongo_client import MongoDBClient
+
+class MongoRepository:
+    def __init__(self, mongo_client: MongoDBClient):
+        self.db = mongo_client.get_db()
+        self.users_collection = self.db["users"]
+        self.documents_collection = self.db["documents"]
+        self.files_collection = self.db["uploaded_files"]
+
+    async def insert_chunks(self, chunks: list):
+        result = await self.documents_collection.insert_many(chunks)
+        return result.inserted_ids
+
+    async def get_user_by_username(self, username: str):
+        return await self.users_collection.find_one({"username": username})
+
+    async def get_user_by_email(self, email: str):
+        return await self.users_collection.find_one({"email": email})
+
+    async def create_user(self, user_data: dict):
+        return await self.users_collection.insert_one(user_data)
+
+    async def save_file(self, file_info: dict):
+        result = await self.files_collection.insert_one(file_info)
+        return result.inserted_id

--- a/app/repositories/qdrant_repository.py
+++ b/app/repositories/qdrant_repository.py
@@ -1,0 +1,60 @@
+from typing import List
+from app.clients.qdrant_client import QdrantDBClient
+from qdrant_client.models import PointStruct, VectorParams, Distance
+import uuid
+import logging
+
+logger = logging.getLogger(__name__)
+
+class QdrantRepository:
+    def __init__(self, qdrant_client: QdrantDBClient):
+        self.qdrant_client = qdrant_client
+        self.collection_name = qdrant_client.collection_name
+        self.client = qdrant_client.get_client()
+        self._ensure_collection_exists()
+
+    def _ensure_collection_exists(self):
+        collections = self.client.get_collections().collections
+        collection_names = [c.name for c in collections]
+        if self.collection_name not in collection_names:
+            logger.info(f"Creating Qdrant collection '{self.collection_name}' with vector size 1024")
+            self.client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(
+                    size=1024,
+                    distance=Distance.COSINE
+                )
+            )
+
+    def insert_vectors(self, points: List[PointStruct]):
+        logger.info("Inserting %d vectors into Qdrant...", len(points))
+        try:
+            self.client.upsert(
+                collection_name=self.collection_name,
+                points=points
+            )
+            logger.info("Successfully inserted vectors into Qdrant.")
+        except Exception as e:
+            logger.error(f"Failed to insert vectors into Qdrant: {e}")
+            raise
+
+    def delete_collection(self):
+        try:
+            self.client.delete_collection(collection_name=self.collection_name)
+            logger.info(f"Deleted Qdrant collection '{self.collection_name}'")
+        except Exception as e:
+            logger.error(f"Error deleting Qdrant collection: {e}")
+            raise
+
+    def search_vectors(self, query_vector: List[float], top_k: int = 5):
+        try:
+            logger.info(f"Searching top {top_k} vectors from Qdrant...")
+            results = self.client.search(
+                collection_name=self.collection_name,
+                query_vector=query_vector,
+                limit=top_k
+            )
+            return results
+        except Exception as e:
+            logger.error(f"Error searching vectors in Qdrant: {e}")
+            raise

--- a/app/services/mongo_service.py
+++ b/app/services/mongo_service.py
@@ -1,27 +1,22 @@
-from app.clients.mongo_client import MongoDBClient
+from app.repositories.mongo_repository import MongoRepository
 
 class MongoService:
-    def __init__(self, mongo_client: MongoDBClient):
-        self.db = mongo_client.get_db()
-        self.users_collection = self.db["users"]
-        self.documents_collection = self.db["documents"]
-        self.files_collection = self.db["uploaded_files"]
+    def __init__(self, mongo_repository: MongoRepository):
+        self.mongo_repository = mongo_repository
 
-    async def insert_chunks(self, chunks: list, user_id: str):
+    async def insert_chunks_with_user(self, chunks: list, user_id: str):
         for chunk in chunks:
             chunk["user_id"] = user_id
-        result = await self.documents_collection.insert_many(chunks)
-        return result.inserted_ids
+        return await self.mongo_repository.insert_chunks(chunks)
 
     async def get_user_by_username(self, username: str):
-        return await self.users_collection.find_one({"username": username})
+        return await self.mongo_repository.get_user_by_username(username)
 
     async def get_user_by_email(self, email: str):
-        return await self.users_collection.find_one({"email": email})
+        return await self.mongo_repository.get_user_by_email(email)
 
     async def create_user(self, user_data: dict):
-        return await self.users_collection.insert_one(user_data)
+        return await self.mongo_repository.create_user(user_data)
 
     async def save_file(self, file_info: dict):
-        result = await self.files_collection.insert_one(file_info)
-        return result.inserted_id
+        return await self.mongo_repository.save_file(file_info)

--- a/app/services/processing.py
+++ b/app/services/processing.py
@@ -2,11 +2,13 @@ from typing import List
 import fitz  # PyMuPDF
 import logging
 from langchain.text_splitter import CharacterTextSplitter
+
 from app.clients.cohere_client import CohereEmbeddingClient
 from app.services.mongo_service import MongoService
 from app.services.qdrant_service import QdrantService
 
 logger = logging.getLogger(__name__)
+
 
 class ProcessingService:
     def __init__(
@@ -58,7 +60,7 @@ class ProcessingService:
             question_embedding = self.embed_texts([question])[0]
 
             # 2. Search Qdrant for top matching chunks
-            results = self.qdrant_service.search_vectors(query_vector=question_embedding, top_k=5)
+            results = self.qdrant_service.search(query_vector=question_embedding, top_k=5)
             if not results:
                 return {"error": "No relevant chunks found to answer the question."}
 

--- a/app/services/qdrant_service.py
+++ b/app/services/qdrant_service.py
@@ -1,69 +1,25 @@
 from typing import List
-from app.clients.qdrant_client import QdrantDBClient
-from qdrant_client.models import PointStruct, VectorParams, Distance
+from qdrant_client.models import PointStruct
+from app.repositories.qdrant_repository import QdrantRepository
 import uuid
-import logging
-
-logger = logging.getLogger(__name__)
 
 class QdrantService:
-    def __init__(self, qdrant_client: QdrantDBClient):
-        self.qdrant_client = qdrant_client
-        self.collection_name = qdrant_client.collection_name
-        self.client = qdrant_client.get_client()
-        self._ensure_collection_exists()
+    def __init__(self, qdrant_repository: QdrantRepository):
+        self.qdrant_repository = qdrant_repository
 
-    def _ensure_collection_exists(self):
-        collections = self.client.get_collections().collections
-        collection_names = [c.name for c in collections]
-        if self.collection_name not in collection_names:
-            logger.info(f"Creating Qdrant collection '{self.collection_name}' with vector size 1024")
-            self.client.create_collection(
-                collection_name=self.collection_name,
-                vectors_config=VectorParams(
-                    size=1024,
-                    distance=Distance.COSINE
-                )
+    def upsert_embeddings_with_metadata(self, embeddings: List[List[float]], metadata: List[dict]):
+        points = [
+            PointStruct(
+                id=str(uuid.uuid4()),
+                vector=embedding,
+                payload=meta
             )
-
-    def insert_vectors(self, embeddings: List[List[float]], metadata: List[dict]):
-        logger.info("Inserting %d vectors into Qdrant...", len(embeddings))
-        try:
-            points = [
-                PointStruct(
-                    id=str(uuid.uuid4()),
-                    vector=embedding,
-                    payload=meta
-                )
-                for embedding, meta in zip(embeddings, metadata)
-            ]
-            self.client.upsert(
-                collection_name=self.collection_name,
-                points=points
-            )
-            logger.info("Successfully inserted vectors into Qdrant.")
-        except Exception as e:
-            logger.error(f"Failed to insert vectors into Qdrant: {e}")
-            raise
+            for embedding, meta in zip(embeddings, metadata)
+        ]
+        self.qdrant_repository.insert_vectors(points)
 
     def delete_collection(self):
-        try:
-            self.client.delete_collection(collection_name=self.collection_name)
-            logger.info(f"Deleted Qdrant collection '{self.collection_name}'")
-        except Exception as e:
-            logger.error(f"Error deleting Qdrant collection: {e}")
-            raise
+        self.qdrant_repository.delete_collection()
 
-    
-    def search_vectors(self, query_vector: List[float], top_k: int = 5):
-        try:
-            logger.info(f"Searching top {top_k} vectors from Qdrant...")
-            results = self.client.search(
-                collection_name=self.collection_name,
-                query_vector=query_vector,
-                limit=top_k
-            )
-            return results
-        except Exception as e:
-            logger.error(f"Error searching vectors in Qdrant: {e}")
-            raise
+    def search(self, query_vector: List[float], top_k: int = 5):
+        return self.qdrant_repository.search_vectors(query_vector, top_k)


### PR DESCRIPTION
### Summary

This PR refactors the architecture by separating concerns between the repository and service layers:

- Moved direct DB access logic from `mongo_service.py` to `mongo_repository.py`
- Moved Qdrant vector logic to `qdrant_repository.py`
- Updated `MongoService` and `QdrantService` to use repositories
- Adjusted `ProcessingService` to use the new service methods
- Updated `core_container.py` to wire clients ➝ repositories ➝ services

### Why?

To follow clean architecture best practices:
- **Repositories** handle low-level persistence logic
- **Services** handle business rules and workflows

### Next Steps

- [ ] Review and test all related routes
- [ ] Add unit tests to mock repository layer if needed