### PR TITLE
Feat/chat

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+.env.*
+*.sqlite3
+*.log
+*.db
+venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
+# Base Python image
 FROM python:3.11-slim
 
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set working directory
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
+# Copy and install Python dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application code
 COPY ./app ./app
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Expose FastAPI port
+EXPOSE 8000
 
-ENV PYTHONUNBUFFERED=1
+# Start the app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/clients/cohere_chat_client.py
+++ b/app/clients/cohere_chat_client.py
@@ -1,18 +1,46 @@
 import cohere
-from typing import List, Optional
+from typing import List, Dict, Optional
 from .llm_interface import LLMChatInterface
 
 class CohereChatClient(LLMChatInterface):
     def __init__(self, api_key: str):
         self.client = cohere.Client(api_key)
 
-    def chat(self, message: str, documents: Optional[List[dict]] = None, system: str = "") -> str:
+    async def chat(
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str] = None,
+        documents: Optional[List[dict]] = None
+    ) -> str:
+        """
+        Multi-turn chat using Cohere's Chat API.
+        """
         try:
+            # Use "message" for Cohere format
+            latest_message = messages[-1].get("message") or messages[-1].get("content")
+
+            # Cohere expects lowercase role: "USER" -> "user", "CHATBOT" -> "assistant"
+            chat_history = []
+            for msg in messages[:-1]:
+                if "message" in msg:
+                    chat_history.append({
+                        "role": msg["role"].lower() if msg["role"] in ("user", "assistant") else msg["role"],
+                        "message": msg["message"]
+                    })
+                elif "content" in msg:
+                    chat_history.append({
+                        "role": msg["role"].lower() if msg["role"] in ("user", "assistant") else msg["role"],
+                        "message": msg["content"]
+                    })
+
             response = self.client.chat(
-                message=message,
+                message=latest_message,
+                chat_history=chat_history,
                 documents=documents,
-                preamble=system
+                preamble=system or ""
             )
+
             return response.text
+
         except Exception as e:
             raise ValueError(f"Cohere chat failed: {str(e)}")

--- a/app/clients/cohere_chat_client.py
+++ b/app/clients/cohere_chat_client.py
@@ -1,21 +1,17 @@
 import cohere
-from typing import List
+from typing import List, Optional
+from .llm_interface import LLMChatInterface
 
-class CohereChatClient:
+class CohereChatClient(LLMChatInterface):
     def __init__(self, api_key: str):
-        self.api_key = api_key
         self.client = cohere.Client(api_key)
 
-    def chat(self, message: str, documents: List[dict] = None, system: str = "") -> str:
-        """
-        Chat with Cohere's LLM.
-        'documents' is an optional list of dicts with a 'text' key.
-        """
+    def chat(self, message: str, documents: Optional[List[dict]] = None, system: str = "") -> str:
         try:
             response = self.client.chat(
                 message=message,
                 documents=documents,
-                preamble=system  # System prompt in Cohere
+                preamble=system
             )
             return response.text
         except Exception as e:

--- a/app/clients/cohere_embedding_client.py
+++ b/app/clients/cohere_embedding_client.py
@@ -1,5 +1,8 @@
 import cohere
+import logging
 from typing import List
+
+logger = logging.getLogger(__name__)
 
 class CohereEmbeddingClient:
     def __init__(
@@ -8,6 +11,7 @@ class CohereEmbeddingClient:
         model: str = "embed-english-v3.0",
         input_type: str = "search_document"
     ):
+        logger.info("Initializing CohereEmbeddingClient")
         self.api_key = api_key
         self.model = model
         self.input_type = input_type
@@ -16,11 +20,25 @@ class CohereEmbeddingClient:
     def embed(self, texts: List[str]) -> List[List[float]]:
         """
         Generate embeddings for a list of texts.
-        Cohere's SDK is synchronous, so no async/await here.
+        Cohere's SDK is synchronous.
         """
-        response = self.client.embed(
-            texts=texts,
-            model=self.model,
-            input_type=self.input_type
-        )
-        return response.embeddings
+        if not texts:
+            logger.warning("embed() called with an empty text list")
+            return []
+
+        logger.info(f"Generating embeddings for {len(texts)} text chunks")
+        preview = texts[0][:100].replace("\n", " ")
+        logger.debug(f"First chunk preview: {preview}...")
+
+
+        try:
+            response = self.client.embed(
+                texts=texts,
+                model=self.model,
+                input_type=self.input_type
+            )
+            logger.info(f"Received {len(response.embeddings)} embeddings from Cohere")
+            return response.embeddings
+        except Exception as e:
+            logger.exception("Error during Cohere embedding request")
+            raise

--- a/app/clients/llm_factory.py
+++ b/app/clients/llm_factory.py
@@ -1,0 +1,30 @@
+from typing import Type
+from app.core.config import settings
+from app.clients.llm_interface import LLMChatInterface
+from app.clients.cohere_chat_client import CohereChatClient
+from app.clients.openai_chat_client import OpenAIChatClient
+
+class LLMChatFactory:
+    _PROVIDERS: dict[str, Type[LLMChatInterface]] = {
+        "cohere": CohereChatClient,
+        "openai": OpenAIChatClient,
+    }
+
+    @classmethod
+    def get_client(cls, provider_name: str) -> LLMChatInterface:
+        if not provider_name:
+            raise ValueError("LLM provider name is required.")
+
+        provider_key = provider_name.lower().strip()
+        if provider_key not in cls._PROVIDERS:
+            raise ValueError(f"Unknown LLM provider: '{provider_name}'")
+
+        api_keys = {
+            "cohere": settings.COHERE_API_KEY,
+            "openai": settings.OPENAI_API_KEY,
+        }
+        api_key = api_keys.get(provider_key)
+        if not api_key:
+            raise ValueError(f"API key for '{provider_name}' is missing.")
+
+        return cls._PROVIDERS[provider_key](api_key=api_key)

--- a/app/clients/llm_interface.py
+++ b/app/clients/llm_interface.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+class LLMChatInterface(ABC):
+    @abstractmethod
+    async def chat(
+        self, user_id: str, question: str, file_id: str, prompt_name: str
+    ) -> dict:
+        """
+        Standard method for answering a question given:
+        - user_id
+        - question text
+        - file_id to search in
+        - prompt_name (for selecting prompt templates)
+        Returns a dict with either {'answer': str} or {'error': str}.
+        """
+        pass
+

--- a/app/clients/llm_interface.py
+++ b/app/clients/llm_interface.py
@@ -1,17 +1,26 @@
 from abc import ABC, abstractmethod
+from typing import List, Dict, Optional
 
 class LLMChatInterface(ABC):
     @abstractmethod
     async def chat(
-        self, user_id: str, question: str, file_id: str, prompt_name: str
-    ) -> dict:
+        self,
+        messages: List[Dict[str, str]],
+        system: Optional[str] = None,
+        documents: Optional[List[dict]] = None
+    ) -> str:
         """
-        Standard method for answering a question given:
-        - user_id
-        - question text
-        - file_id to search in
-        - prompt_name (for selecting prompt templates)
-        Returns a dict with either {'answer': str} or {'error': str}.
+        Multi-turn chat with an LLM.
+
+        Args:
+            messages: Conversation history as a list of dicts 
+                      [{"role": "user"/"assistant"/"system", "content": str}]
+            system: Optional system message to guide behavior.
+            documents: Optional retrieved documents for context (RAG).
+
+        Returns:
+            Assistant's reply as a string.
         """
         pass
+
 

--- a/app/clients/openai_chat_client.py
+++ b/app/clients/openai_chat_client.py
@@ -1,0 +1,35 @@
+import openai
+from typing import List, Optional
+from app.clients.llm_interface import LLMChatInterface
+
+class OpenAIChatClient(LLMChatInterface):
+    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+        self.client = openai.OpenAI(api_key=api_key)
+        self.model = model
+
+    def chat(self, message: str, documents: Optional[List[dict]] = None, system: str = "") -> str:
+        """
+        Uses the new OpenAI SDK (>=1.0.0) chat interface.
+        Matches the CohereChatClient interface.
+        """
+        try:
+            # Combine documents into context string
+            context = ""
+            if documents:
+                context = "\n\n".join([doc.get("text", "") for doc in documents])
+
+            user_message = f"{message}\n\nContext:\n{context}" if context else message
+
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user_message}
+                ],
+                max_tokens=300
+            )
+
+            return response.choices[0].message.content
+
+        except Exception as e:
+            raise ValueError(f"OpenAI chat failed: {str(e)}")

--- a/app/container/core_container.py
+++ b/app/container/core_container.py
@@ -4,13 +4,14 @@ from app.clients.cohere_embedding_client import CohereEmbeddingClient
 
 from app.repositories.mongo_repository import MongoRepository
 from app.repositories.qdrant_repository import QdrantRepository
+from app.repositories.prompt_repository import PromptRepository
 
 from app.services.file_processing import FileProcessingService
 from app.services.semantic_search import SemanticSearchService
 from app.services.llm_search import LLMSearchService
-from app.clients.cohere_chat_client import CohereChatClient
+
 from app.core.config import settings
-from app.repositories.prompt_repository import PromptRepository
+
 # === Clients ===
 mongo_client = MongoDBClient(
     uri=settings.MONGO_URI,
@@ -23,13 +24,13 @@ qdrant_client = QdrantDBClient(
     collection_name=settings.QDRANT_COLLECTION,
 )
 
-
 cohere_embedding_client = CohereEmbeddingClient(api_key=settings.COHERE_API_KEY)
-cohere_chat_client = CohereChatClient(api_key=settings.COHERE_API_KEY)
+
 # === Repositories ===
 mongo_repository = MongoRepository(mongo_client)
 qdrant_repository = QdrantRepository(qdrant_client)
 prompt_repository = PromptRepository(mongo_client.db)
+
 # === Services ===
 semantic_search_service = SemanticSearchService(
     cohere_client=cohere_embedding_client,
@@ -41,34 +42,31 @@ file_processing_service = FileProcessingService(
     semantic_search_service=semantic_search_service
 )
 
+# LLMSearchService no longer needs provider at init
 llm_search_service = LLMSearchService(
     semantic_search_service=semantic_search_service,
     cohere_embedding_client=cohere_embedding_client,
-    cohere_chat_client=cohere_chat_client,
     qdrant_repository=qdrant_repository,
     mongo_repository=mongo_repository,
-    prompt_repository=prompt_repository 
+    prompt_repository=prompt_repository
 )
 
 # === Container Class ===
 class Container:
     def __init__(self):
-        # Clients
         self.mongo_client = mongo_client
         self.qdrant_client = qdrant_client
         self.cohere_client = cohere_embedding_client
 
-        # Repositories
         self.mongo_repository = mongo_repository
         self.qdrant_repository = qdrant_repository
         self.prompt_repository = prompt_repository
 
-        # Services
         self.semantic_search_service = semantic_search_service
         self.file_processing_service = file_processing_service
         self.llm_search_service = llm_search_service
 
-        # Alias for route usage
         self.file_search_service = file_processing_service
+
 
 container = Container()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,17 +1,24 @@
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
-    COHERE_API_KEY: str
+    # MongoDB
     MONGO_URI: str
     MONGODB_DATABASE: str
 
+    # Qdrant
     QDRANT_URL: str
     QDRANT_API_KEY: str
     QDRANT_COLLECTION: str
 
+    # Auth
     SECRET_KEY: str
     ALGORITHM: str
     ACCESS_TOKEN_EXPIRE_MINUTES: int
+
+    # LLM provider settings
+    LLM_PROVIDER: str | None = None # "cohere" or "openai"
+    COHERE_API_KEY: str
+    OPENAI_API_KEY: str
 
     class Config:
         env_file = ".env"

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ app.add_middleware(
 app.include_router(auth_routes.router, prefix="/auth", tags=["Authentication"])
 app.include_router(file_routes.router, prefix="/upload", tags=["Upload"])
 app.include_router(search_routes.router, prefix="/search", tags=["Search"])
-app.include_router(question_routes.router, prefix="/questions", tags=["Questions"])
+app.include_router(question_routes.router, prefix="/chat", tags=["chat"])
 app.include_router(file_routes.router, prefix="/files", tags=["Files"])
 # Root endpoint
 @app.get("/")

--- a/app/routes/question_routes.py
+++ b/app/routes/question_routes.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional
+
 from app.security.deps import get_current_user
 from app.container.core_container import container
 from app.models.user import User
@@ -9,20 +10,37 @@ router = APIRouter()
 
 class QuestionRequest(BaseModel):
     question: str
-    file_id: str   
+    file_id: str
     prompt_name: str
+    provider_name: Optional[str] = "cohere"  # default to cohere
+
+    @field_validator("provider_name")
+    def validate_provider(cls, v):
+        allowed_providers = {"cohere", "openai"}  # keep consistent with factory
+        if v and v.lower() not in allowed_providers:
+            raise ValueError(f"provider_name must be one of {allowed_providers}")
+        return v.lower() if v else "cohere"
+
+
 @router.post("/ask")
-async def ask_question(request: QuestionRequest, current_user: dict = Depends(get_current_user)):
+async def ask_question(
+    request: QuestionRequest,
+    current_user: dict = Depends(get_current_user)
+):
+    """
+    Route delegates orchestration to LLMSearchService.
+    LLMSearchService will pick the LLM client via LLMChatFactory based on provider_name.
+    """
+    # Use container's llm_search_service and pass provider_name to the service method
     result = await container.llm_search_service.answer_question(
         user_id=current_user["sub"],
+        provider_name=request.provider_name,
         question=request.question,
-        file_id=request.file_id,
-        prompt_name=request.prompt_name, 
-        # <-- pass file_id to the method
+        prompt_name=request.prompt_name,
+        file_id=request.file_id
     )
 
     if "error" in result:
         raise HTTPException(status_code=400, detail=result["error"])
 
     return result
-

--- a/app/services/llm_search.py
+++ b/app/services/llm_search.py
@@ -1,4 +1,8 @@
 import logging
+from typing import Optional, Dict, Any
+
+from app.clients.llm_factory import LLMChatFactory
+from app.core.config import settings
 from app.clients.cohere_embedding_client import CohereEmbeddingClient
 from app.repositories.qdrant_repository import QdrantRepository
 from app.repositories.mongo_repository import MongoRepository
@@ -7,19 +11,25 @@ from app.services.semantic_search import SemanticSearchService
 
 logger = logging.getLogger(__name__)
 
+
 class LLMSearchService:
+    """
+    Service for answering user questions by:
+    - Retrieving the appropriate prompt template
+    - Performing semantic search for relevant chunks
+    - Calling the selected LLM provider to generate a response
+    """
+
     def __init__(
         self,
-        semantic_search_service,
-        cohere_embedding_client,
-        cohere_chat_client,
-        qdrant_repository,
-        mongo_repository,
-        prompt_repository
+        semantic_search_service: SemanticSearchService,
+        cohere_embedding_client: CohereEmbeddingClient,
+        qdrant_repository: QdrantRepository,
+        mongo_repository: MongoRepository,
+        prompt_repository: PromptRepository,
     ):
         self.semantic_search_service = semantic_search_service
         self.cohere_embedding_client = cohere_embedding_client
-        self.cohere_chat_client = cohere_chat_client
         self.qdrant_repository = qdrant_repository
         self.mongo_repository = mongo_repository
         self.prompt_repository = prompt_repository
@@ -28,16 +38,28 @@ class LLMSearchService:
         self,
         user_id: str,
         question: str,
+        file_id: Optional[str],
         prompt_name: str = "default",
         language: str = "english",
-        file_id: str = None
-    ) -> dict:
+        provider_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
-        Search relevant context from vector DB, build prompt from MongoDB template,
-        and get an answer from the LLM.
+        Answer a question using the specified LLM provider.
+
+        :param user_id: ID of the current user
+        :param question: User's question
+        :param file_id: Optional file ID for context restriction
+        :param prompt_name: Name of the prompt template
+        :param language: Language of the response
+        :param provider_name: Which LLM to use ("cohere" or "openai")
         """
         try:
-            # 1. Fetch prompt template from MongoDB
+            provider = (provider_name or settings.LLM_PROVIDER).lower()
+
+            # 1. Instantiate LLM client for this request
+            llm_client = LLMChatFactory.get_client(provider)
+
+            # 2. Fetch prompt template
             prompt_doc = await self.prompt_repository.get_prompt_by_name(prompt_name)
             if not prompt_doc:
                 return {"error": f"No prompt found with name '{prompt_name}'"}
@@ -45,11 +67,11 @@ class LLMSearchService:
             system_text = prompt_doc.get("system", "")
             user_template = prompt_doc.get("user", "")
 
-            # 2. Embed the question
+            # 3. Embed the question
             embedding = self.cohere_embedding_client.embed([question])
             query_vector = embedding[0]
 
-            # 3. Search Qdrant for relevant chunks
+            # 4. Search for relevant chunks
             results = self.qdrant_repository.search_vectors(
                 query_vector=query_vector,
                 file_id=file_id,
@@ -58,23 +80,26 @@ class LLMSearchService:
             if not results:
                 return {"error": "No relevant context found."}
 
-            # 4. Extract clean text chunks
-            context_chunks = []
-            for hit in results[:3]:
-                text_chunk = hit.payload.get("text", "")
-                context_chunks.append(str(text_chunk))
+            # 5. Extract top chunks
+            context_chunks = [
+                str(hit.payload.get("text", "")) for hit in results[:3]
+            ]
             context = "\n".join(context_chunks)
 
-            # 5. Build the final prompt by replacing placeholders
-            final_user_prompt = user_template.format(question=question, context=context)
+            # 6. Build the user prompt
+            final_user_prompt = user_template.format(
+                question=question,
+                context=context,
+                language=language
+            )
 
-            # 6. Call Cohere LLM
-            response = self.cohere_chat_client.chat(message=final_user_prompt, system=system_text)
+            # 7. Call the LLM
+            response_text =  llm_client.chat(
+     message=final_user_prompt,
+    system=system_text)
 
-            return {"answer": response}
+            return {"answer": response_text}
 
         except Exception as e:
             logger.exception("Failed to answer question")
             return {"error": f"Failed to answer question: {str(e)}"}
-
-    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-
 services:
   mongo:
     image: mongo:latest
@@ -8,10 +7,11 @@ services:
   qdrant:
     image: qdrant/qdrant
     ports:
-    - "6340:6333" 
+      - "6340:6333"
 
   app:
     build: .
+    image: rahma561/docsearch-app:latest   # <— Important: This is your Docker Hub repo
     ports:
       - "8000:8000"
     env_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pydantic[email]
 langchain
 pyPDF2
 aiofiles
+openai


### PR DESCRIPTION
## Summary
This PR introduces two major updates to the project:
1. **Refactor LLM route** — Converted the existing `/ask` endpoint into a `/chat` endpoint to enable persistent conversational context with the LLM.
2. **Containerization improvements** — Added a production-ready `Dockerfile` and `docker-compose.yaml` to streamline development and deployment.

## Changes
- Replaced `/ask` route with `/chat` route.
  - Added conversation state management to handle multi-turn interactions.
  - Updated API documentation and client usage examples.
- Created a `Dockerfile` to build the application image.
- Added `docker-compose.yaml` with services for:
  - Application container
  - MongoDB
  - Qdrant
- Configured environment variables via `.env` file for cleaner setup.
- Verified images build and run locally.
- Pushed images to Docker Hub (`rahma561/docsearch-app`).

## Motivation
- **LLM route refactor:** Improve user experience by enabling interactive chat with contextual memory instead of isolated queries.
- **Containerization:** Ensure consistent environments for development, testing, and deployment, reducing "works on my machine" issues.

## Testing
- Manually tested `/chat` endpoint with various conversation flows.
- Confirmed Docker image builds successfully via:
  ```bash
  docker build -t rahma561/docsearch-app:latest .
  docker-compose up
